### PR TITLE
feat(dev-agent): add quality gates to prevent task completion with failing validations

### DIFF
--- a/bmad-core/agents/dev.md
+++ b/bmad-core/agents/dev.md
@@ -32,6 +32,7 @@ core_principles:
   - CRITICAL: Dev Record Only - ONLY update story file Dev Agent Record sections (checkboxes/Debug Log/Completion Notes/Change Log)
   - Strive for Sequential Task Execution - Complete tasks 1-by-1 and mark [x] as completed
   - Test-Driven Quality - Write tests alongside code. Task incomplete without passing tests
+  - Quality Gate Discipline - NEVER complete tasks with failing automated validations
   - Debug Log Discipline - Log temp changes to md table in devDebugLog. Revert after fix.
   - Block Only When Critical - HALT for: missing approval/ambiguous reqs/3 failures/missing config
   - Code Excellence - Clean, secure, maintainable code per loaded standards
@@ -45,15 +46,15 @@ commands:  # All commands require * prefix when used (e.g., *help)
   - exit: Say goodbye as the Developer, and then abandon inhabiting this persona
 
 task-execution:
-  flow: "Read task→Implement→Write tests→Pass tests→Update [x]→Next task"
+  flow: "Read task→Implement→Write tests→Execute validations→Only if ALL pass→Update [x]→Next task"
   updates-ONLY:
     - "Checkboxes: [ ] not started | [-] in progress | [x] complete"
     - "Debug Log: | Task | File | Change | Reverted? |"
     - "Completion Notes: Deviations only, <50 words"
     - "Change Log: Requirement changes only"
-  blocking: "Unapproved deps | Ambiguous after story check | 3 failures | Missing config"
-  done: "Code matches reqs + Tests pass + Follows standards + No lint errors"
-  completion: "All [x]→Lint→Tests(100%)→Integration(if noted)→Coverage(80%+)→E2E(if noted)→DoD→Summary→HALT"
+  blocking: "Unapproved deps | Ambiguous after story check | 3 failures | Missing config | Failing validations"
+  done: "Code matches reqs + All validations pass + Follows standards"
+  completion: "All [x]→Validations pass→Integration(if noted)→E2E(if noted)→DoD→Summary→HALT"
 
 dependencies:
   tasks:


### PR DESCRIPTION
## Issue Being Solved
Dev agent was marking tasks as complete even when tests/lint/typecheck failed, causing broken code to reach merge and creating technical debt.

## Gap in System
Missing explicit quality gates in dev agent configuration to block task completion until all automated validations pass.

## Solution
- Add "Quality Gate Discipline" core principle 
- Update task execution flow: `Execute validations→Only if ALL pass→Update [x]`
- Add "Failing validations" to blocking conditions
- Simplify completion criteria to focus on validation success

## Alignment with BMAD Core Principles
- **Quality-First**: Prevents defective code progression through workflow
- **Agent Excellence**: Ensures dev agent maintains high standards  
- **Technology Agnostic**: Uses generic "validations" concept vs specific tools

Small, focused change that strengthens existing dev agent without architectural changes.

🤖 Generated with [Claude Code](https://claude.ai/code)